### PR TITLE
Fixing Connection issue

### DIFF
--- a/rebirthdb/net.py
+++ b/rebirthdb/net.py
@@ -408,8 +408,10 @@ class SocketWrapper(object):
                     raise ReqlTimeoutError(self.host, self.port)
                 except IOError as ex:
                     if ex.errno == errno.ECONNRESET:
+                        self.close()
                         raise ReqlDriverError("Connection is closed.")
                     elif ex.errno == errno.EWOULDBLOCK:
+                        self.close()
                         # This should only happen with a timeout of 0
                         raise ReqlTimeoutError(self.host, self.port)
                     elif ex.errno != errno.EINTR:
@@ -417,10 +419,9 @@ class SocketWrapper(object):
                                                'receiving from %s:%s - %s') %
                                               (self.host, self.port, str(ex)))
                 except Exception as ex:
+                    self.close()
                     raise ReqlDriverError('Error receiving from %s:%s - %s' %
                                           (self.host, self.port, str(ex)))
-                finally:
-                    self.close()
 
             if len(chunk) == 0:
                 self.close()


### PR DESCRIPTION
## Related issue
Issue https://github.com/RebirthDB/rebirthdb-python/issues/6

## Description
The refactoring of `net.py` made in commit https://github.com/RebirthDB/rebirthdb-python/commit/89db318a85cd940f0de0fba8e4f31b96b9acb697 closes the connection anyway not only when exception occurred.

## Traceback
```
traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "rebirthdb/net.py", line 722, in connect
    return conn.reconnect(timeout=timeout)
  File "rebirthdb/net.py", line 617, in reconnect
    return self._instance.connect(timeout)
  File "rebirthdb/net.py", line 473, in connect
    self._socket = SocketWrapper(self, timeout)
  File "rebirthdb/net.py", line 306, in __init__
    self._socket = socket.create_connection((self.host, self.port), timeout)
rebirthdb.errors.ReqlDriverError: Could not connect to localhost:28015. Error: 'NoneType' object has no attribute 'settimeout'
```

## Later improvements
When refactoring the package, we should figure out a nicer way to handle these kind of socket closes.