### PR TITLE
Skip coverage upload on PRs without encrypted key.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,7 @@ test-integration:
 	pytest -m integration
 
 upload-coverage:
-	if [ "$TRAVIS_PULL_REQUEST" != "" ]; then
-		if [ "$CODACY_PROJECT_TOKEN" = "" ]; then
-			@echo "Skipping coverage upload for PR or missing CODACY_PROJECT_TOKEN"
-			exit;
-		fi
-	fi
-	pytest -m unit --cov rebirthdb --cov-report xml
-	python-codacy-coverage -r coverage.xml
+	@sh scripts/upload-coverage.sh
 
 clean:
 	@rm -rf \
@@ -83,4 +76,3 @@ package: prepare
 
 publish:
 	cd ${BUILD_DIR} && python ./setup.py register upload
-

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,12 @@ test-integration:
 	pytest -m integration
 
 upload-coverage:
+	if [ "$TRAVIS_PULL_REQUEST" != "" ]; then
+		if [ "$CODACY_PROJECT_TOKEN" = "" ]; then
+			@echo "Skipping coverage upload for PR or missing CODACY_PROJECT_TOKEN"
+			exit;
+		fi
+	fi
 	pytest -m unit --cov rebirthdb --cov-report xml
 	python-codacy-coverage -r coverage.xml
 

--- a/scripts/upload-coverage.sh
+++ b/scripts/upload-coverage.sh
@@ -1,0 +1,8 @@
+if [ "${TRAVIS_PULL_REQUEST}" != "" ]; then
+    if [ "${CODACY_PROJECT_TOKEN}" = "" ]; then
+        echo "Skipping coverage upload for PR or missing CODACY_PROJECT_TOKEN"
+        exit;
+    fi
+fi
+pytest -m unit --cov rebirthdb --cov-report xml
+python-codacy-coverage -r coverage.xml


### PR DESCRIPTION
Experimenting with travis keys. This should lead to few false positives, and will notify that the problem is likely a missing local environment variable.