### PR TITLE
Implement integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ jobs:
           python: "3.6"
           script: make upload-coverage
 
-        # - stage: integration_test
-        #  if: branch = master
-        #  script: make test-integration
+        - stage: integration_test
+          if: branch = master
+          script: make test-integration
 
 before_script:
     - make prepare
-    
+
 script:
     - make test-unit

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ TARGET_PROTO_FILE = ${PACKAGE_NAME}/${PROTO_FILE_NAME}
 FILE_CONVERTER_NAME = convert_protofile.py
 FILE_CONVERTER_URL = https://raw.githubusercontent.com/RebirthDB/rebirthdb/next/scripts/${FILE_CONVERTER_NAME}
 
+REMOTE_TEST_SETUP_NAME = prepare_remote_test.py
+REMOTE_TEST_SETUP_URL = https://raw.githubusercontent.com/RebirthDB/rebirthdb/next/scripts/${REMOTE_TEST_SETUP_NAME}
+
 CONVERTED_PROTO_FILE_NAME = ql2_pb2.py
 TARGET_CONVERTED_PROTO_FILE = ${PACKAGE_NAME}/${CONVERTED_PROTO_FILE_NAME}
 
@@ -48,7 +51,8 @@ test-unit:
 	pytest -m unit
 
 test-integration:
-	pytest -m integration
+	curl -qo ${REMOTE_TEST_SETUP_NAME} ${REMOTE_TEST_SETUP_URL}
+	python ${REMOTE_TEST_SETUP_NAME} pytest -m integration
 
 upload-coverage:
 	@sh scripts/upload-coverage.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ codacy-coverage==1.3.11
 mock==2.0.0
 pytest-cov==2.5.1
 pytest==3.7.1
+paramiko==2.4.1
+python-digitalocean==1.13.2

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+import os
 from rebirthdb import RebirthDB
 
 
@@ -8,8 +9,13 @@ class IntegrationTestCaseBase(object):
     r = RebirthDB()
     conn = None
 
+    def connect(self):
+        self.conn = self.r.connect(
+            host=os.getenv('REBIRTHDB_HOST')
+        )
+
     def setup_method(self):
-        self.conn = self.r.connect()
+        self.connect()
 
         if INTEGRATION_TEST_DB not in self.r.db_list().run(self.conn):
             self.r.db_create(INTEGRATION_TEST_DB).run(self.conn)

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -8,7 +8,7 @@ class TestREPL(IntegrationTestCaseBase):
 
     def setup_method(self):
         super(TestREPL, self).setup_method()
-        self.conn = self.r.connect().repl()
+        self.conn = self.conn.repl()
 
     def test_repl_does_not_require_conn(self):
         databases = self.r.db_list().run()


### PR DESCRIPTION
## Description
In order to run remote tests on DO nodes, we need to set up a droplet, install rebirthdb, run tests (integration, performance or regression) and clean up after the tests, to not waste resources.

## Workflow
1. Create an "in-memory" ssh key with paramiko
2. Create an SSH key on DO
3. Create droplet
4. Add debian package and install rebirthdb
5. Create a default configuration file
6. Start/Restart rebirthdb
7. Run integration tests
8. Remove SSH key and droplet 

## Example output
```
[2018-08-06T09:32:18.006548]	generating ssh key
[2018-08-06T09:32:18.122468]	create ssh key on DigitalOcean
[2018-08-06T09:32:18.762295]	creating droplet
[2018-08-06T09:32:20.327846]	waiting for droplet to be ready
[2018-08-06T09:32:47.484535]	connecting to droplet
[2018-08-06T09:33:10.783060]	getting rebirthdb
[2018-08-06T09:33:10.783129]	executing source /etc/lsb-release && echo "deb https://dl.bintray.com/floydkots/apt $DISTRIB_CODENAME main" | tee /etc/apt/sources.list.d/rebirthdb.list
[2018-08-06T09:33:11.358472]	executing wget -qO- https://dl.bintray.com/floydkots/keys/pubkey.gpg | apt-key add -
[2018-08-06T09:33:12.392463]	installing rebirthdb
[2018-08-06T09:33:12.392495]	executing apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y rebirthdb
[2018-08-06T09:33:29.986438]	executing echo "bind=all" > /etc/rebirthdb/instances.d/default.conf
[2018-08-06T09:33:30.602472]	restarting rebirthdb
[2018-08-06T09:33:30.602521]	executing /etc/init.d/rebirthdb restart
[2018-08-06T09:33:31.261257]	executing script
======================================================================== test session starts ========================================================================
platform darwin -- Python 2.7.10, pytest-3.7.1, py-1.5.4, pluggy-0.7.1
rootdir: /Users/buco/python/github.com/RebirthDB/rebirthdb-python, inifile: setup.cfg
plugins: xdist-1.22.5, forked-0.2, cov-2.5.1
collected 6 items / 5 deselected

tests/test_repl.py .                                                                                                                                          [100%]

============================================================== 1 passed, 5 deselected in 1.59 seconds ===============================================================
[2018-08-06T09:33:33.259663]	destroying droplet
[2018-08-06T09:33:33.962999]	removing ssh key
```