### PR TITLE
Extending readme and makefile with the remote integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
 
         - stage: integration_test
           if: branch = master
-          script: make test-integration
+          script: make test-remote
 
 before_script:
     - make prepare

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test-unit:
 	pytest -m unit
 
 test-integration:
-	python pytest -m integration
+	pytest -m integration
 
 test-remote: prepare
 	python ${REMOTE_TEST_SETUP_NAME} pytest -m integration

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ help:
 	@echo "	make help				Print this help message"
 	@echo "	make test-unit			Run unit tests"
 	@echo "	make test-integration	Run integration tests"
+	@echo "	make test-remote		Run tests on digital ocean"
 	@echo "	make upload-coverage	Upload unit test coverage"
 	@echo "	make clean				Cleanup source directory"
 	@echo "	make prepare			Prepare ${PACKAGE_NAME} for build"
@@ -51,7 +52,9 @@ test-unit:
 	pytest -m unit
 
 test-integration:
-	curl -qo ${REMOTE_TEST_SETUP_NAME} ${REMOTE_TEST_SETUP_URL}
+	python pytest -m integration
+
+test-remote: prepare
 	python ${REMOTE_TEST_SETUP_NAME} pytest -m integration
 
 upload-coverage:
@@ -71,6 +74,7 @@ clean:
 prepare:
 	curl -qo ${TARGET_PROTO_FILE} ${PROTO_FILE_URL}
 	curl -qo ${FILE_CONVERTER_NAME} ${FILE_CONVERTER_URL}
+	curl -qo ${REMOTE_TEST_SETUP_NAME} ${REMOTE_TEST_SETUP_URL}
 	python ./${FILE_CONVERTER_NAME} -l python -i ${TARGET_PROTO_FILE} -o ${TARGET_CONVERTED_PROTO_FILE}
 	rsync -av ./ ${BUILD_DIR} --filter=':- .gitignore'
 	cp ${TARGET_PROTO_FILE} ${BUILD_DIR}/${PACKAGE_NAME}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for hero in marvel_heroes.run(connection):
 ```
 
 ## Run tests
-In the `Makefile` you can find three different test commands: `test-unit`, `test-integration` and `test-remote`. As RebirthDB dropping the support of Windows, we would like to ensure that those of us who are using Windows for development can still contribute. Because of this, we support running integration tests against Digital Ocean Droplets as well.
+In the `Makefile` you can find three different test commands: `test-unit`, `test-integration` and `test-remote`. As RebirthDB has dropped the support of Windows, we would like to ensure that those of us who are using Windows for development can still contribute. Because of this, we support running integration tests against Digital Ocean Droplets as well.
 
 Before you run any test, make sure that you install the requirements.
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ r = RebirthDB()
 connection = r.connect(db='test')
 
 r.table_create('marvel').run(connection)
+
 marvel_heroes = r.table('marvel')
 marvel_heroes.insert({
     'id': 1,
@@ -44,7 +45,40 @@ for hero in marvel_heroes.run(connection):
 ```
 
 ## Run tests
-To ensure python driver works with python 2.7, 3.4, 3.5, 3.6 we are using `tox` and `pytest`. For testing (depending on what you would like to test) you can run `tox` or `pytest`.
+In the `Makefile` you can find three different test commands: `test-unit`, `test-integration` and `test-remote`. As RebirthDB dropping the support of Windows, we would like to ensure that those of us who are using Windows for development can still contribute. Because of this, we support running integration tests against Digital Ocean Droplets as well.
+
+Before you run any test, make sure that you install the requirements.
+```bash
+$ pip install -r requirements.txt
+```
+
+### Running unit tests
+```bash
+$ make test-unit
+```
+
+### Running integration tests
+*To run integration tests locally, make sure you intstalled RebirthDB*
+```bash
+$ make test-integration
+```
+
+### Running remote integration tests
+*To run the remote tests, you need to have a Digital Ocean account and an API key.*
+
+Remote test will create a new temporary SSH key and a Droplet for you until the tests are finished.
+
+**Available environment variables**
+| Variable name | Default value |
+|---------------|---------------|
+| DO_TOKEN      | N/A           |
+| DO_SIZE       | 512MB         |
+| DO_REGION     | sfo2          |
+
+```bash
+$ export DO_TOKEN=<YOUR_TOKEN>
+$ make test-remote
+```
 
 ## New features
 Github's Issue tracker is **ONLY** used for reporting bugs. NO NEW FEATURE ACCEPTED! Use [spectrum](https://spectrum.chat/rebirthdb) for supporting features.


### PR DESCRIPTION
## Description
Due to we have more and more testing methods (unit testing, integration testing and remote integration testing) I'm extending the `Makefile` and `README` to represent the changes we made so far.