### PR TITLE
Fix env variable table display

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ $ make test-integration
 Remote test will create a new temporary SSH key and a Droplet for you until the tests are finished.
 
 **Available environment variables**
+
 | Variable name | Default value |
 |---------------|---------------|
 | DO_TOKEN      | N/A           |


### PR DESCRIPTION
## Description
The environment variables' table is not shown, instead it was broken. This PR adds a newline which will fix the issue.