### PR TITLE
Create connection integration.

### DIFF
--- a/rebirthdb/net.py
+++ b/rebirthdb/net.py
@@ -400,10 +400,10 @@ class SocketWrapper(object):
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
                 self._socket.close()
-            except ReqlError as ex:
-                default_logger.error(ex.message)
-            except Exception as ex:
-                default_logger.error(ex)
+            except ReqlError as exc:
+                default_logger.error(exc.message)
+            except Exception as exc:
+                default_logger.error(exc)
             finally:
                 self._socket = None
 

--- a/rebirthdb/net.py
+++ b/rebirthdb/net.py
@@ -29,9 +29,22 @@ import time
 
 from rebirthdb import ql2_pb2
 from rebirthdb.ast import DB, ReQLDecoder, ReQLEncoder, Repl, expr
-from rebirthdb.errors import ReqlAuthError, ReqlCursorEmpty, ReqlDriverError, ReqlInternalError, ReqlNonExistenceError,\
-    ReqlOpFailedError, ReqlOpIndeterminateError, ReqlPermissionError, ReqlQueryLogicError, ReqlResourceLimitError,\
-    ReqlRuntimeError, ReqlServerCompileError, ReqlTimeoutError, ReqlUserError
+from rebirthdb.errors import (
+    ReqlAuthError,
+    ReqlCursorEmpty,
+    ReqlDriverError,
+    ReqlError,
+    ReqlInternalError,
+    ReqlNonExistenceError,
+    ReqlOpFailedError,
+    ReqlOpIndeterminateError,
+    ReqlPermissionError,
+    ReqlQueryLogicError,
+    ReqlResourceLimitError,
+    ReqlRuntimeError,
+    ReqlServerCompileError,
+    ReqlTimeoutError,
+    ReqlUserError)
 from rebirthdb.handshake import HandshakeV0_4, HandshakeV1_0
 from rebirthdb.logger import default_logger
 
@@ -387,8 +400,10 @@ class SocketWrapper(object):
             try:
                 self._socket.shutdown(socket.SHUT_RDWR)
                 self._socket.close()
-            except Exception as ex:
+            except ReqlError as ex:
                 default_logger.error(ex.message)
+            except Exception as ex:
+                default_logger.error(ex)
             finally:
                 self._socket = None
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -11,10 +11,12 @@ class IntegrationTestCaseBase(object):
 
     def connect(self):
         self.conn = self.r.connect(
-            host=os.getenv('REBIRTHDB_HOST')
+            host=self.rebirthdb_host
         )
 
     def setup_method(self):
+        self.rebirthdb_host=os.getenv('REBIRTHDB_HOST')
+
         self.connect()
 
         if INTEGRATION_TEST_DB not in self.r.db_list().run(self.conn):

--- a/tests/integration/test_ping.py
+++ b/tests/integration/test_ping.py
@@ -4,6 +4,9 @@ import pytest
 from tests.helpers import IntegrationTestCaseBase
 
 
+BAD_PASSWORD = "0xDEADBEEF"
+
+
 @pytest.mark.integration
 class TestPing(IntegrationTestCaseBase):
     def teardown_method(self):
@@ -15,12 +18,13 @@ class TestPing(IntegrationTestCaseBase):
 
     def test_bad_password(self):
         with pytest.raises(self.r.ReqlAuthError):
-            self.r.connect(password="0xDEADBEEF", host=self.rebirthdb_host)
+            self.r.connect(password=BAD_PASSWORD, host=self.rebirthdb_host)
 
     def test_password_connect(self):
+        new_user = "user"
         with self.r.connect(user="admin", password="", host=self.rebirthdb_host) as conn:
             curr = self.r.db("rethinkdb").table("users").insert(
-                {"id": "user", "password": "0xDEADBEEF"}
+                {"id": new_user, "password": BAD_PASSWORD}
             ).run(conn)
             assert curr == {
                 'deleted': 0,

--- a/tests/integration/test_ping.py
+++ b/tests/integration/test_ping.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+
+from tests.helpers import IntegrationTestCaseBase
+
+
+@pytest.mark.integration
+class TestPing(IntegrationTestCaseBase):
+    def setup_method(self):
+        super(TestPing, self).setup_method()
+        self.rebirthdb_host=os.getenv('REBIRTHDB_HOST')
+
+    def teardown_method(self):
+        with self.r.connect(host=self.rebirthdb_host) as conn:
+            curr = self.r.db("rethinkdb").table("users").filter(
+                self.r.row["id"].ne("admin")
+            ).delete().run(conn)
+            assert list(curr)
+        super(TestPing, self).teardown_method()
+
+    def test_bad_password(self):
+        with pytest.raises(self.r.ReqlAuthError):
+            self.r.connect(password="0xDEADBEEF", host=self.rebirthdb_host)
+
+    def test_password_connect(self):
+        with self.r.connect(user="admin", password="", host=self.rebirthdb_host) as conn:
+            curr = self.r.db("rethinkdb").table("users").insert(
+                {"id": "user", "password": "0xDEADBEEF"}
+            ).run(conn)
+            assert curr == {
+                'deleted': 0,
+                'errors': 0,
+                'inserted': 1,
+                'replaced': 0,
+                'skipped': 0,
+                'unchanged': 0}
+            curr = self.r.db("rethinkdb").grant("user", {"read": True}).run(conn)
+            assert curr == {
+                'granted': 1,
+                'permissions_changes': [
+                    {
+                        'new_val': {'read': True},
+                        'old_val': None}]}
+        with self.r.connect(user="user", password="0xDEADBEEF", host=self.rebirthdb_host) as conn:
+            curr = self.r.db("rethinkdb").table("users").get("admin").run(conn)
+            assert curr == {'id': 'admin', 'password': False}
+            with pytest.raises(self.r.ReqlPermissionError):
+                curr = self.r.db("rethinkdb").table("users").insert(
+                    {"id": "bob", "password": ""}
+                ).run(conn)
+                assert curr is False
+
+    def test_context_manager(self):
+        with self.r.connect(host=self.rebirthdb_host) as conn:
+            assert conn.is_open() is True
+        assert conn.is_open() is False

--- a/tests/integration/test_ping.py
+++ b/tests/integration/test_ping.py
@@ -6,10 +6,6 @@ from tests.helpers import IntegrationTestCaseBase
 
 @pytest.mark.integration
 class TestPing(IntegrationTestCaseBase):
-    def setup_method(self):
-        super(TestPing, self).setup_method()
-        self.rebirthdb_host=os.getenv('REBIRTHDB_HOST')
-
     def teardown_method(self):
         with self.r.connect(host=self.rebirthdb_host) as conn:
             curr = self.r.db("rethinkdb").table("users").filter(


### PR DESCRIPTION
Started work on #23. This is being run against RebirthDB/rebirthdb next. Found and fixed a bug where `OSError` gets caught here on some permission denied cases. Tests for integration up to finding the bug are included. It should be noted here that the system db is still `"rethinkdb"`.