### PR TITLE
Extend logger to be able to write to stdout/stderr

### DIFF
--- a/rebirthdb/logger.py
+++ b/rebirthdb/logger.py
@@ -56,13 +56,15 @@ class DriverLogger(object):
 
         return str(message)
 
-    def _log(self, level, message, *args, **kwargs):
+    def _print_message(self, level, message):
         if self.write_to_console:
             if level <= logging.WARNING:
                 sys.stdout.write(message)
             else:
                 sys.stderr.write(message)
 
+    def _log(self, level, message, *args, **kwargs):
+        self._print_message(level, message)
         self.logger.log(level, message, args, kwargs)
 
     def debug(self, message):

--- a/rebirthdb/logger.py
+++ b/rebirthdb/logger.py
@@ -18,6 +18,7 @@ Wrap logging package to not repeat general logging steps.
 
 
 import logging
+import sys
 
 
 class DriverLogger(object):
@@ -37,8 +38,10 @@ class DriverLogger(object):
         log_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
         logging.basicConfig(format=log_format)
 
-        self.log = logging.getLogger()
-        self.log.setLevel(level)
+        self.logger = logging.getLogger()
+        self.logger.setLevel(level)
+
+        self.write_to_console = False
 
     @staticmethod
     def _convert_message(message):
@@ -53,6 +56,15 @@ class DriverLogger(object):
 
         return str(message)
 
+    def _log(self, level, message, *args, **kwargs):
+        if self.write_to_console:
+            if level <= logging.WARNING:
+                sys.stdout.write(message)
+            else:
+                sys.stderr.write(message)
+
+        self.logger.log(level, message, args, kwargs)
+
     def debug(self, message):
         """
         Log debug messages.
@@ -62,7 +74,7 @@ class DriverLogger(object):
         :rtype: None
         """
 
-        self.log.debug(message)
+        self._log(logging.DEBUG, message)
 
     def info(self, message):
         """
@@ -73,7 +85,7 @@ class DriverLogger(object):
         :rtype: None
         """
 
-        self.log.info(message)
+        self._log(logging.INFO, message)
 
     def warning(self, message):
         """
@@ -84,7 +96,7 @@ class DriverLogger(object):
         :rtype: None
         """
 
-        self.log.warning(message)
+        self._log(logging.WARNING, message)
 
     def error(self, message):
         """
@@ -95,7 +107,7 @@ class DriverLogger(object):
         :rtype: None
         """
 
-        self.log.error(message)
+        self._log(logging.ERROR, message)
 
     def exception(self, message):
         """
@@ -106,7 +118,7 @@ class DriverLogger(object):
         :rtype: None
         """
 
-        self.log.exception(self._convert_message(message))
+        self._log(logging.ERROR, self._convert_message(message), exc_info=1)
 
 
 default_logger = DriverLogger()


### PR DESCRIPTION
## Description
Adding functionality to the logger to be able to write to stdout/stderr.
This feature was requested in https://github.com/RebirthDB/rebirthdb-python/pull/9/files/8328cc1a20e57615da7163cd50148e5042741bdc#diff-565263873ac3f2f37ce9d01ee9bd638a